### PR TITLE
Add a synchronous parsing function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ npm install ofx-js
 Example usage:
 
 ```javascript
-import {parse as parseOFX} from 'ofx-js';
+import {parseSync as parseOFX} from 'ofx-js';
 
 const ofxString = readFile("bank-statement.ofx");
 
-parseOFX(ofxString).then(ofxData => {
-    const statementResponse = ofxData.OFX.BANKMSGSRSV1.STMTTRNRS.STMTRS;
-    const accountId = statementResponse.BANKACCTFROM.ACCTID;
-    const currencyCode = statementResponse.CURDEF;
-    const transactionStatement = statementResponse.BANKTRANLIST.STMTTRN;
-    // do something...
-});
+const ofxData = parseOFX(ofxString);
+
+const statementResponse = ofxData.OFX.BANKMSGSRSV1.STMTTRNRS.STMTRS;
+const accountId = statementResponse.BANKACCTFROM.ACCTID;
+const currencyCode = statementResponse.CURDEF;
+const transactionStatement = statementResponse.BANKTRANLIST.STMTTRN;
+// do something...
 ```

--- a/ofx.js
+++ b/ofx.js
@@ -150,20 +150,13 @@ function convertAstToObject(astNode) {
  * @returns {Promise} A promise that will resolve to the parsed XML as a JSON-style object
  */
 function parseXml(xml) {
-    return new Promise((resolve, reject) => {
-        try {
-            const ast = parseXmlString(xml);
-            if (!ast) {
-                reject(new Error("Failed to parse XML"));
-                return;
-            }
-            const result = {};
-            result[ast.name] = convertAstToObject(ast);
-            resolve(result);
-        } catch (err) {
-            reject(err);
-        }
-    });
+    const ast = parseXmlString(xml);
+    if (!ast) {
+        throw new Error("Failed to parse XML");
+    }
+    const result = {};
+    result[ast.name] = convertAstToObject(ast);
+    return result;
 }
 
 /**
@@ -171,7 +164,7 @@ function parseXml(xml) {
  * @param {string} data The OFX data to parse
  * @returns {Promise} A promise that will resolve to the parsed data.
  */
-function parse(data) {
+function parseSync(data) {
     // firstly, split into the header attributes and the footer sgml
     const ofx = data.split('<OFX>', 2);
 
@@ -188,15 +181,25 @@ function parse(data) {
 
     // Parse the XML/SGML portion of the file into an object
     // Try as XML first, and if that fails do the SGML->XML mangling
-    return parseXml(content).catch(() => {
-        // XML parse failed.
-        // Do the SGML->XML Manging and try again.
-        return parseXml(sgml2Xml(content));
-    }).then(data => {
-        // Put the headers into the returned data
-        data.header = header;
-        return data;
-    });
+    let result;
+    try {
+        result = parseXml(content);
+    } catch (err) {
+        result = parseXml(sgml2Xml(content));
+    }
+    result.header = header;
+    return result;
+}
+
+/**
+ * Given a string of OFX data, parse it asynchronously.
+ * This function is only here for backward-compatibility purposes.
+ * @param {string} data The OFX data to parse
+ * @returns {Promise} A promise that will resolve to the parsed data.
+ */
+async function parse(data) {
+    return parseSync(data);
 }
 
 module.exports.parse = parse;
+module.exports.parseSync = parseSync;


### PR DESCRIPTION
Sometimes you don't need your code to run in an async way, and the added complexity of either handling a `Promise` or `async`/`await` is just not worth it.

And here the `Promise` is a little bit artificial anyway since everything underneath runs synchronously anyway (there is no non-blocking API that's called under the hood).

I actually believe the library should actually just be entirely synchronous, but for the sake backward compatibility this PR doesn't change the public API and simply adds a `parseSync` function.