### PR TITLE
Clean up tests, bump supported NodeJS versions

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,6 +1,9 @@
 name: Run tests (Node.js)
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   build:
@@ -8,12 +11,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['14.x', '16.x', '18.x']
+        node-version: ['22.x', '24.x', '26.x']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
       "url": "https://webb.codes"
     }
   ],
-  "devDependencies": {
-    "tape": "^4.6.3"
-  },
+  "devDependencies": {},
   "dependencies": {},
   "main": "./ofx.js",
   "directories": {},
@@ -36,6 +34,6 @@
     "export"
   ],
   "scripts": {
-    "test": "tape test/*.js"
+    "test": "node --test test/*.js"
   }
 }

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,67 +1,57 @@
-// core
-var fs = require('fs');
-var test = require('tape');
+const fs = require('fs');
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
 
-// local
-var ofx = require('..');
+const ofx = require('..');
 
-test('parse', t => {
+test('parse example1', async () => {
     const file = fs.readFileSync(__dirname + '/data/example1.ofx', 'utf8');
-    ofx.parse(file).then(data => {
-        // headers
-        t.equal(data.header.OFXHEADER, '100');
-        t.equal(data.header.ENCODING, 'USASCII');
+    const data = await ofx.parse(file);
 
-        var transactions = data.OFX.BANKMSGSRSV1.STMTTRNRS.STMTRS.BANKTRANLIST.STMTTRN;
-        t.equal(transactions.length, 5);
+    assert.equal(data.header.OFXHEADER, '100');
+    assert.equal(data.header.ENCODING, 'USASCII');
 
-        var status = data.OFX.SIGNONMSGSRSV1.SONRS.STATUS;
-        t.equal(status.CODE, '0');
-        t.equal(status.SEVERITY, 'INFO');
+    const transactions = data.OFX.BANKMSGSRSV1.STMTTRNRS.STMTRS.BANKTRANLIST.STMTTRN;
+    assert.equal(transactions.length, 5);
 
-        t.end();
-    });
+    const status = data.OFX.SIGNONMSGSRSV1.SONRS.STATUS;
+    assert.equal(status.CODE, '0');
+    assert.equal(status.SEVERITY, 'INFO');
 });
 
-test('parse 2', t => {
+test('parse example2', async () => {
     const file = fs.readFileSync(__dirname + '/data/example2.ofx', 'utf8');
-    ofx.parse(file).then(data => {
-        // headers
-        t.equal(data.header.OFXHEADER, '100');
-        t.equal(data.header.ENCODING, 'USASCII');
+    const data = await ofx.parse(file);
 
-        var transactions = data.OFX.BANKMSGSRSV1.STMTTRNRS.STMTRS.BANKTRANLIST.STMTTRN;
-        t.equal(transactions.length, 29);
-        t.equal(transactions[0].TRNAMT, "-45.54");
+    assert.equal(data.header.OFXHEADER, '100');
+    assert.equal(data.header.ENCODING, 'USASCII');
 
-        var status = data.OFX.SIGNONMSGSRSV1.SONRS.STATUS;
-        t.equal(status.CODE, '0');
-        t.equal(status.SEVERITY, 'INFO');
+    const transactions = data.OFX.BANKMSGSRSV1.STMTTRNRS.STMTRS.BANKTRANLIST.STMTTRN;
+    assert.equal(transactions.length, 29);
+    assert.equal(transactions[0].TRNAMT, "-45.54");
 
-        t.end();
-    });
+    const status = data.OFX.SIGNONMSGSRSV1.SONRS.STATUS;
+    assert.equal(status.CODE, '0');
+    assert.equal(status.SEVERITY, 'INFO');
 });
 
-test('parse XML', t => {
+test('parse XML', async () => {
     const file = fs.readFileSync(__dirname + '/data/example-xml.qfx', 'utf8');
-    ofx.parse(file).then(data => {
-        // headers
-        t.equal(data.header.OFXHEADER, '100');
-        t.equal(data.header.ENCODING, 'USASCII');
+    const data = await ofx.parse(file);
 
-        var transaction = data.OFX.BANKMSGSRSV1.STMTTRNRS.STMTRS.BANKTRANLIST.STMTTRN;
-        t.same(transaction, {
-            TRNTYPE: 'INT',
-            DTPOSTED: '20161215000550',
-            TRNAMT: '0.84',
-            FITID: '21172131531687',
-            NAME: 'Interest Paid'
-        });
+    assert.equal(data.header.OFXHEADER, '100');
+    assert.equal(data.header.ENCODING, 'USASCII');
 
-        var status = data.OFX.SIGNONMSGSRSV1.SONRS.STATUS;
-        t.equal(status.CODE, '0');
-        t.equal(status.SEVERITY, 'INFO');
-
-        t.end();
+    const transaction = data.OFX.BANKMSGSRSV1.STMTTRNRS.STMTRS.BANKTRANLIST.STMTTRN;
+    assert.deepEqual(transaction, {
+        TRNTYPE: 'INT',
+        DTPOSTED: '20161215000550',
+        TRNAMT: '0.84',
+        FITID: '21172131531687',
+        NAME: 'Interest Paid'
     });
-})
+
+    const status = data.OFX.SIGNONMSGSRSV1.SONRS.STATUS;
+    assert.equal(status.CODE, '0');
+    assert.equal(status.SEVERITY, 'INFO');
+});


### PR DESCRIPTION
* Update GitHub Actions config so tests run on every PR, not just on push to master
* Change NodeJS versions used for testing to 22, 24, 26
* Bump `actions/checkout` and `actions/setup-node` to latest
* Convert tests to use `node:test` runner instead of `tape`